### PR TITLE
Set indent level to 2 spaces

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,10 @@
 default: test
 
 test:
-  cargo test
+	cargo test
+
+fmt:
+	cargo fmt
 
 doc:
-  cargo doc --all --open
+	cargo doc --all --open

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+tab_spaces = 2
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+  println!("Hello, world!");
 }


### PR DESCRIPTION
Add two spaces as the default for rustfmt.