### PR TITLE
Initialize library database

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,12 +47,12 @@ test_script:
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
       cargo rustc --target %TARGET%                      &&
-      cargo rustc --target %TARGET% --release            &&
       cargo fmt -- --check                               &&
       cargo test --target %TARGET%                       &&
-      cargo test --target %TARGET% --release             &&
-      cargo run --target %TARGET% -- --version           &&
-      cargo run --target %TARGET% --release -- --version
+      cargo run --target %TARGET% -- --version
+      # cargo rustc --target %TARGET% --release
+      # cargo test --target %TARGET% --release
+      # cargo run --target %TARGET% --release
     )
 
 before_deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,12 +46,12 @@ test_script:
   - cargo fmt -- --check
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo rustc --target %TARGET% &&
-      cargo rustc --target %TARGET% --release &&
-      cargo fmt -- --check                                                       &&
-      cargo test --target %TARGET%                                               &&
-      cargo test --target %TARGET% --release                                     &&
-      cargo run --target %TARGET% -- --version                                   &&
+      cargo rustc --target %TARGET%                      &&
+      cargo rustc --target %TARGET% --release            &&
+      cargo fmt -- --check                               &&
+      cargo test --target %TARGET%                       &&
+      cargo test --target %TARGET% --release             &&
+      cargo run --target %TARGET% -- --version           &&
       cargo run --target %TARGET% --release -- --version
     )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,9 +50,6 @@ test_script:
       cargo fmt -- --check                               &&
       cargo test --target %TARGET%                       &&
       cargo run --target %TARGET% -- --version
-      # cargo rustc --target %TARGET% --release
-      # cargo test --target %TARGET% --release
-      # cargo run --target %TARGET% --release
     )
 
 before_deploy:

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,7 +5,6 @@ set -ex
 # DONE This is the "test phase", tweak it as you see fit
 main() {
     cross build --target $TARGET
-    # cross build --target $TARGET --release
 
     if [ ! -z $DISABLE_TESTS ]; then
         return
@@ -14,10 +13,8 @@ main() {
     cross fmt -- --check
 
     cross test --target $TARGET
-    # cross test --target $TARGET --release
 
     cross run --target $TARGET -- --version
-    # cross run --target $TARGET --release -- --version
 }
 
 # we don't run the "test phase" when doing deploys

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,7 +5,7 @@ set -ex
 # DONE This is the "test phase", tweak it as you see fit
 main() {
     cross build --target $TARGET
-    cross build --target $TARGET --release
+    # cross build --target $TARGET --release
 
     if [ ! -z $DISABLE_TESTS ]; then
         return
@@ -14,10 +14,10 @@ main() {
     cross fmt -- --check
 
     cross test --target $TARGET
-    cross test --target $TARGET --release
+    # cross test --target $TARGET --release
 
     cross run --target $TARGET -- --version
-    cross run --target $TARGET --release -- --version
+    # cross run --target $TARGET --release -- --version
 }
 
 # we don't run the "test phase" when doing deploys

--- a/justfile
+++ b/justfile
@@ -3,6 +3,10 @@ default: test
 
 log='warn'
 
+bt='0'
+
+export RUST_BACKTRACE = bt
+
 # run tests
 test:
 	cargo test
@@ -12,9 +16,13 @@ fmt:
 	cargo fmt
 
 # run linter
-lint:
-	@echo Running clippy...
-	@cargo +nightly clippy -- \
+@lint:
+	echo Checking for TODO/FIX/XXX...
+	! grep --color -En 'TODO|FIX|XXX' src/*.rs
+	echo Checking for lines over 100 columns...
+	! grep --color -En '.{101}' src/*.rs
+	echo Invoking clippy...
+	cargo +nightly clippy -- \
 		-D clippy \
 		-D clippy_style \
 		-D clippy_complexity \
@@ -40,6 +48,11 @@ check:
 # count non-empty lines of code
 sloc:
 	@cat src/*.rs | sed '/^\s*$/d' | wc -l
+
+pr: fmt lint test
+	git diff --no-ext-diff --quiet --exit-code
+	[ `git rev-parse --abbrev-ref HEAD` != master ]
+	git push upstream
 
 # run a command, defaulting to `node`
 run command='node': build

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,10 +9,16 @@ pub enum Error {
   /// Application directory was not a directory
   AppDirectoryNotDirectory { path: PathBuf },
   /// Library file path had extension other than `.db`
-  LibraryPathExtension { library_path: PathBuf },
+  LibraryPathExtension { database_path: PathBuf },
   /// Error accessing the library database
-  LibraryDatabase {
+  LibrarySqlite {
     sqlite_error: rusqlite::Error,
-    library_path: PathBuf,
+    statement: Option<String>,
+    database_path: PathBuf,
+  },
+  /// Pre-existing library database had an invalid application id
+  LibraryApplicationId {
+    application_id: i32,
+    database_path: PathBuf,
   },
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,5 +1,6 @@
 use common::*;
 
+/// `true` if running on Appveyor CI
 pub fn running_on_appveyor() -> bool {
   env::var_os("APPVEYOR").is_some()
 }


### PR DESCRIPTION
Currently we only need to set the database `application_id` and `journal_mode` to `0x13370000` and `wal` respectively.

The former is a sanity check to make sure that the database we're opening is indeed a ele database. The latter is for increased concurrency.

I've started to add some rusqlite related wrappers and helper functions.

Also of note is the `pr` just recipe, which formats, lints, tests, checks for no git diffs, checks that we're on a branch other than master, and pushes to the `upstream` remote.

The `lint` recipe is expanded to check for long lines and complain about TODOs.

I noticed that CI was building and testing twice, once in debug mode and once in release mode. I removed building/testing in release mode, since it takes substantially longer than debug mode. This brings CI time down to 2-3 minutes.

We'll want to make sure that we test in release mode whenever we publish a new release, so I'm working on a just recipe to do all that.