### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+# Text is UTF-8
+charset = utf-8
+# Unix-style newlines
+end_of_line = lf
+# Newline ending every file
+insert_final_newline = true
+# Soft tabs
+indent_style = space
+# Two-space indentation
+indent_size = 2
+# Trim trailing whitespace
+trim_trailing_whitespace = true
+
+[justfile]
+# Use tabs in justfile
+indent_style = tab


### PR DESCRIPTION
Sets defaults for text editors, details here: https://editorconfig.org

I added all the editor config values that seem useful. Some might wind up being annoying, like `trim_trailing_whitespace`, but we can tweak if need be.

Vim plugin here:
https://github.com/editorconfig/editorconfig-vim

Emacs plugin here:
https://github.com/editorconfig/editorconfig-emacs
